### PR TITLE
Add prior art section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,10 @@ This alternative would partition the HSTS cache entries by the top-level site. D
 
 This option was not selected because our proposed solution has comparable security benefits and allows HSTS registrations from third-parties to apply to any top-level navigations.
 
+## Prior Art
+
+Other browsers, Safari and Firefox, have previously implemented their own version of HSTS tracking preventions. While these designs differ from ours, they nonetheless informed our approach.
+ 
+* WebKit - [Protecting Against HSTS Abuse | WebKit](https://webkit.org/blog/8146/protecting-against-hsts-abuse/)
+* Mozilla - [Bug 1701192 - don't allow third-party loads to set HSTS state](https://hg.mozilla.org/integration/autoland/rev/9bae0f6ea847) 
 


### PR DESCRIPTION
Closes #2 

Adds a prior art section listing Firefox's and Safari's previous work.